### PR TITLE
chore: Show Vaadin status bar item only for Vaadin projects

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,6 +22,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(newProjectCommand);
 
 	if (isVaadinProject()) {
+		statusBarItem.show();
 		startServer();
 	}
 

--- a/src/helpers/server.ts
+++ b/src/helpers/server.ts
@@ -11,7 +11,6 @@ const httpServer: Server = createServer(express());
 export let statusBarItem: vscode.StatusBarItem;
 statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 0);
 updateStatusBarItem(false);
-statusBarItem.show();
 
 export async function startServer() {
 


### PR DESCRIPTION
## Description

Show Vaadin status bar icon only for Vaadin projects. Command still can be run manually.

Fixes #15 
