### PR TITLE
feat: Use Task to focus window

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -1,9 +1,7 @@
 name: Validate
 
 on:
-  push:
-    branches-ignore:
-      - main
+  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/src/helpers/handlers.ts
+++ b/src/helpers/handlers.ts
@@ -4,6 +4,7 @@ import { Uri } from 'vscode';
 import * as fs from 'fs';
 import { isFileInsideProject } from './projectFilesHelpers';
 import { undoManager } from './undoManager';
+import { focusWindow } from './ideUtils';
 
 export enum Handlers {
     WRITE = "write",
@@ -126,6 +127,7 @@ export async function showInIdeHandler(data: ShowInIdeCommandData) {
         const range = new vscode.Range(data.line, data.column, data.line, data.column);
         editor.revealRange(range, vscode.TextEditorRevealType.InCenter);
         console.log('Opening document ' + data.file + ' at ' + data.line + ':' + data.column);
+        focusWindow();
     } else {
         console.warn("File " + data.file + " is not a part of a project");
     }

--- a/src/helpers/ideUtils.ts
+++ b/src/helpers/ideUtils.ts
@@ -1,0 +1,38 @@
+import * as vscode from 'vscode';
+import { getProjectFilePath } from './projectFilesHelpers';
+
+function escapePath(path: string): string {
+    if (process.platform === 'win32') {
+        // On Windows, escape backslashes and spaces
+        return path.replace(/\\/g, '\\\\').replace(/ /g, '\\ ');
+    } else {
+        // On Unix-based systems, escape spaces with a backslash
+        return path.replace(/ /g, '\\ ');
+    }
+}
+
+const closeElectronTerminal = (n: number = 100) => setTimeout(() => {
+    const electronTerminal = vscode.window.terminals.find(v => v.name === 'Electron');
+    if (electronTerminal) {
+        electronTerminal.dispose();
+    } else if (n > 0) {
+        closeElectronTerminal(n--);
+    }
+}, 100);
+
+// using exec() spawns child_process and it does not focus window, workaround as below works
+export function focusWindow() {
+    if (process.env._) {
+        const task = new vscode.Task(
+            {   
+                type: 'shell',
+            },
+            vscode.TaskScope.Workspace,
+            'bringToFront',
+            'vaadin',
+            new vscode.ShellExecution(`${escapePath(process.env._!)} "${getProjectFilePath()}"`)
+        );
+        vscode.tasks.executeTask(task);
+        closeElectronTerminal();
+    }
+}

--- a/src/helpers/ideUtils.ts
+++ b/src/helpers/ideUtils.ts
@@ -32,7 +32,6 @@ export function focusWindow() {
             'vaadin',
             new vscode.ShellExecution(`${escapePath(process.env._!)} "${getProjectFilePath()}"`)
         );
-        vscode.tasks.executeTask(task);
-        closeElectronTerminal();
+        vscode.tasks.executeTask(task).then(() => closeElectronTerminal());
     }
 }


### PR DESCRIPTION
## Description

Use Task execution to focus window.

causes known vscode issue:
https://github.com/microsoft/vscode/issues/176670

In Output > Tasks there is:
```
Activating task providers java
Error: the task 'vaadin: bringToFront' neither specifies a command nor a dependsOn property. The task will be ignored. Its definition is:
{
    "type": "shell",
    "id": "shell,/Applications/Visual\\ Studio\\ Code.app/Contents/MacOS/Electron \"/Users/vaadin/src/copilot\",",
    "problemMatcher": [],
    "label": "vaadin: bringToFront"
}
Error: the task 'vaadin: bringToFront' neither specifies a command nor a dependsOn property. The task will be ignored. Its definition is:
{
    "type": "shell",
    "id": "shell,/Applications/Visual\\ Studio\\ Code.app/Contents/MacOS/Electron \"/Users/vaadin/src/copilot\",",
    "problemMatcher": [],
    "label": "vaadin: bringToFront"
}
```

EDIT: Does not work on Windows due to different executable variable and differences in execution (command line / powershell).