### PR TITLE
feat: implement HelloWorld in Vaadin Create project action

### DIFF
--- a/src/helpers/projectFilesHelpers.ts
+++ b/src/helpers/projectFilesHelpers.ts
@@ -63,14 +63,10 @@ export async function downloadAndExtract(model: ProjectModel) {
     throw new Error('No project folder found in the downloaded zip');
   }
   const extractedRoot = path.join(tempExtractPath, extractedFolders[0]);
+
+
+  // Always use the provided model.name as the destination folder (already checked for conflicts)
   const projectPath = path.join(model.location, model.name);
-
-  // If the destination folder already exists, remove it first
-  if (fs.existsSync(projectPath)) {
-    fs.rmSync(projectPath, { recursive: true, force: true });
-  }
-
-  // Move the extracted folder to the expected destination name
   fs.renameSync(extractedRoot, projectPath);
 
   // Clean up temporary folder


### PR DESCRIPTION
**Vaadin Project Generation Improvements**

- Added a workflow selector: users can choose between "Starter Project" (minimal skeleton) and "Hello World Project" (basic demo) when creating a new Vaadin project.
- Each workflow presents only the relevant options (framework, language, build tool, architecture, etc.) in the input wizard.
- The project download URL is generated according to the selected workflow and user options, matching the official Vaadin starter endpoints.
- The downloaded project is always extracted to a folder named as specified by the user, regardless of the zip’s internal structure.
- If the target folder already exists, the wizard proposes a new available folder name (e.g., `name-1`, `name-2`, etc.) and asks the user for confirmation before proceeding.
- The folder name conflict logic is handled before downloading, ensuring no unnecessary downloads or overwrites.