### PR TITLE
feat: Add hotswap option to Run menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,13 @@
       }
     },
     "menus": {
+      "editor/title/run": [
+        {
+          "command": "vaadin.debugUsingHotswap",
+          "group": "1_javadebug@30",
+          "when": "resourceExtname == .java"
+        }
+      ],
       "explorer/context": [
         {
           "command": "vaadin.debugUsingHotswap",


### PR DESCRIPTION
## Summary
- add hotswap debug command to editor Run menu for Java files
- place after Java Debug entry using 1_javadebug group

## Testing
- not run (UI contribution only)

Fixes #47