### PR TITLE
feat: Configure hotswap automatically on startup

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,7 +4,7 @@ import { statusBarItem, startServer } from './helpers/server';
 import { newProjectUserInput } from './helpers/userInput';
 import { undoManager } from './helpers/undoManager';
 import { deleteProperties } from './helpers/properties';
-import { debugUsingHotswap, setupHotswap } from './helpers/hotswap';
+import { checkBundledHotswapAgentVersion, debugUsingHotswap, setupHotswap } from './helpers/hotswap';
 import { DebugCodeLensProvider } from './debug-using-hotswapagent';
 import { StyleSheetLinkProvider } from './stylesheet-link-provider';
 import { getJavaExtensionId, JAVA_DEBUG_CONFIGURATION, JAVA_LANGID, ORACLE_JAVA_EXTENSION_ID } from './helpers/javaUtil';
@@ -61,6 +61,8 @@ export async function activate(context: vscode.ExtensionContext) {
   }
 
   trackPluginInitialized();
+
+  checkBundledHotswapAgentVersion(context);
 
   vscode.workspace.onDidSaveTextDocument((doc) => undoManager.documentSaveListener(doc));
 }

--- a/src/helpers/hotswap.ts
+++ b/src/helpers/hotswap.ts
@@ -30,6 +30,9 @@ class JavaRuntimeQuickPickItem implements QuickPickItem {
   constructor(item: IJavaRuntime | undefined) {
     this.item = item;
     this.label = item?.version?.java_version || 'unknown';
+    if (item?.homedir) {
+      this.description = item?.homedir;
+    }
     if (!item) {
       this.label = 'Download from https://github.com/JetBrains/JetBrainsRuntime';
     }
@@ -386,7 +389,7 @@ export async function checkBundledHotswapAgentVersion(context: ExtensionContext)
   const installedVersion = getJarVersion(installedJarPath);
 
   // install hotswap-agent.jar if not present
-  if (!installedVersion || bundledVersion != installedVersion) {
+  if (!installedVersion || bundledVersion !== installedVersion) {
     setupHotswap(context, true);
   }
 


### PR DESCRIPTION
Checks if bundled hotswap version is newer and performs update automatically on extension startup.

Installs hotswap to `~/.vaadin/vscode-plugin/` instead of given JBR.